### PR TITLE
Fixes #9 Changes to support NodeJS 12

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,8 +1,8 @@
-{  
-    "targets":[  
-        {  
+{
+    "targets":[
+        {
             "target_name":"rpi-ws281x",
-            "sources":[  
+            "sources":[
                 "src/addon.cpp",
                 "./src/rpi_ws281x/ws2811.c",
                 "./src/rpi_ws281x/pwm.c",
@@ -11,14 +11,14 @@
                 "./src/rpi_ws281x/rpihw.c",
                 "./src/rpi_ws281x/pcm.c"
             ],
-            "include_dirs":[  
+            "include_dirs":[
                 "<!(node -e \"require('nan')\")"
             ],
-            "ldflags":[  
+            "ldflags":[
                 "-lrt"
             ],
-            "cflags":[  
-                "-Wall -O3 -g"
+            "cflags":[
+                "-Wall -O3 -g -Wno-cast-function-type"
             ]
         }
     ]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "git-commit": "make git-commit",
     "git-revert": "make git-revert",
     "npm-publish": "make npm-publish"
-
   },
   "keywords": [
     "ws2811",
@@ -31,6 +30,6 @@
   },
   "dependencies": {
     "nan": "^2.14.0"
-  },  
+  },
   "homepage": "https://github.com/meg768/rpi-ws281x#readme"
 }

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -109,15 +109,15 @@ NAN_METHOD(Addon::configure)
     if (true) {
         v8::Local<v8::Value> stripType = options->Get(Nan::New<v8::String>("type").ToLocalChecked());
 
-        if (stripType->IsUndefined()) 
+        if (stripType->IsUndefined())
             stripType = options->Get(Nan::New<v8::String>("strip").ToLocalChecked());
 
-        if (stripType->IsUndefined()) 
+        if (stripType->IsUndefined())
             stripType = options->Get(Nan::New<v8::String>("stripType").ToLocalChecked());
 
         if (!stripType->IsUndefined()) {
-            v8::String::Utf8Value value(stripType->ToString());
-            string stripTypeValue = string(*value);        
+            v8::String::Utf8Value value(v8::Isolate::GetCurrent(), Nan::To<v8::String>(stripType).ToLocalChecked()); //  stripType->ToString(Nan::GetCurrentContext()).FromMaybe(v8::Local<v8::String>()));
+            string stripTypeValue = string(*value);
 
             if (stripTypeValue == "rgb") {
                 ws2811.channel[0].strip_type = WS2811_STRIP_RGB;
@@ -189,7 +189,7 @@ NAN_METHOD(Addon::render)
     v8::Local<v8::Uint32Array> array = info[0].As<v8::Uint32Array>();
     v8::Local<v8::Uint32Array> mapping = info[1].As<v8::Uint32Array>();
 
-    
+
     if ((uint32_t)(array->Buffer()->GetContents().ByteLength()) != (uint32_t)(4 * ws2811.channel[0].count))
 		return Nan::ThrowError("Size of pixels does not match.");
 
@@ -214,7 +214,7 @@ NAN_METHOD(Addon::sleep)
 {
 	Nan::HandleScope();
 
-    usleep(info[0]->Int32Value() * 1000);
+    usleep(info[0]->ToInt32(Nan::GetCurrentContext()).ToLocalChecked()->Value() * 1000);
 
     info.GetReturnValue().Set(Nan::Undefined());
 


### PR DESCRIPTION
Changes tested to work with NodeJS 10 and NodeJS 8.11.2, 10.14.2 and 12.18.1.

I did test against 14.15.1, but it looks like there will need to be some extra changes needed there, since we run into a build failure there:

```cpp
../src/addon.cpp:67:93: warning: ‘v8::Local<v8::Value> v8::Object::Get(v8::Local<v8::Value>)’ is deprecated: Use maybe version [-Wdeprecated-declarations]
     v8::Maybe<v8::Value> debug = options->Get(Nan::New<v8::String>("debug").ToLocalChecked());
```

 Since this is already showing as a deprecation back in 8.x builds, I am going to see if I can find a solution, but so far I haven't had much luck. In the meantime I have requested help on [StackOverflow](https://stackoverflow.com/questions/64961662/).