### PR TITLE
fix(documentation): strip type fix in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ class Example {
         // are "rgb", "rbg", "grb", "gbr", "bgr", "brg".
         // Default is "rgb".
         // RGBW strips are not currently supported.
-        this.config.type = 'grb';
+        this.config.stripType = 'grb';
 
         // Configure ws281x
         ws281x.configure(this.config);


### PR DESCRIPTION
Hi @meg768 ! 

After spending a couple of hours asking myself why my led strip wasn't showing the right color I figured out that it was the kind of strip that is not RGB based but GRB for some reason. So I switched the config.type according to your example in the readme but sadly it did not change anything.
After further investigation in the addon.cpp file, I just found that the correct config attribute was config.stripType.

So here I am with this simple pull request to update the documentation in order to save some dev time to other devs with weird non-rgb LEDs!

Btw thanks for your lib!
